### PR TITLE
[Task3] multiple target trees circle motion

### DIFF
--- a/jsk_uav_forest_common/launch/challenge.launch
+++ b/jsk_uav_forest_common/launch/challenge.launch
@@ -6,6 +6,7 @@
   <arg name="do_mapping" default="False" />
   <arg name="turn_before_return" default="False" />
   <arg name="do_avoidance" default="True" />
+  <arg name="target_num" default="1" />
 
   <!-- bringup -->
   <include file="$(find jsk_uav_forest_common)/launch/m100_bringup.launch" >
@@ -34,6 +35,7 @@
     <arg name="rqt_gui" value="$(arg rqt_gui)" />
     <arg name="turn_before_return" value="$(arg turn_before_return)" />
     <arg name="do_avoidance" value="$(arg do_avoidance)" />
+    <arg name="target_num" value="$(arg target_num)" />
   </include>
 
   <!-- 2D SLAM -->

--- a/jsk_uav_forest_common/launch/debug.launch
+++ b/jsk_uav_forest_common/launch/debug.launch
@@ -40,7 +40,7 @@
     <param name="only_target" value="false" />
     <param name="tree_radius_max" value="0.4" /> <!-- max raidus for tree circle fitting-->
     <param name="search_radius" value="10.0" />
-    <param name="display_num" value="5" />
+    <param name="valid_num" value="5" />
     <param name="verbose" value="false" />
     <param name="uav_tilt_thre" value="0.07" />
     <param name="visualization" value="true" />

--- a/jsk_uav_forest_motion/launch/motion.launch
+++ b/jsk_uav_forest_motion/launch/motion.launch
@@ -5,6 +5,7 @@
   <arg name="task_kind" default="1" />
   <arg name="rqt_gui" default="False" />
   <arg name="circle_motion_times" default="1" />
+  <arg name="target_num" default="1" />
   <arg name="turn_before_return" default="True" />
   <arg name="do_avoidance" default="False" />
 
@@ -18,6 +19,7 @@
   <node pkg="jsk_uav_forest_motion" type="motion.py" name="motion" output="screen" args="$(arg use_dji)">
     <param name="task_kind" value="$(arg task_kind)" />
     <param name="do_avoidance" value="$(arg do_avoidance)" />
+    <param name="target_num" value="$(arg target_num)" />
     <param name="circle_motion_times" value="$(arg circle_motion_times)" />
     <param name="turn_before_return" value="$(arg turn_before_return)" />
     <param name="uav_odom_sub_topic_name" value="$(arg uav_odom_topic_name)"/>

--- a/jsk_uav_forest_motion/script/motion.py
+++ b/jsk_uav_forest_motion/script/motion.py
@@ -407,9 +407,9 @@ class ForestMotion:
                         res = update_target_tree()
 
                         if res.success:
-                            time.sleep(0.5)
                             self.state_machine_ = self.TREE_DETECTION_START_STATE_
                             self.tree_pos_update_flag_ = False
+                            time.sleep(0.5)
                             return
                     except rospy.ServiceException, e:
                         print "Service call failed: %s"%e

--- a/jsk_uav_forest_perception/include/jsk_uav_forest_perception/tree_database.h
+++ b/jsk_uav_forest_perception/include/jsk_uav_forest_perception/tree_database.h
@@ -58,7 +58,7 @@ public:
   TreeHandle(): pos_(0,0,0), vote_(0), radius_(0) {}
   TreeHandle(ros::NodeHandle nh, ros::NodeHandle nhp, tf::Vector3 pos);
   ~TreeHandle(){}
-  
+
   boost::shared_ptr<TreeHandle> getHandle() { return boost::shared_ptr<TreeHandle>(this); }
   void updatePos(const tf::Vector3& pos, bool lpf = true);
   void setRadius(double radius, bool lpf = true);
@@ -91,13 +91,20 @@ public:
 
   void update();
   void visualization(std_msgs::Header header);
+
+  int validTreeNum()
+  {
+    return (trees_.size()>valid_num_)?valid_num_:trees_.size();
+  }
+
+  inline void getTrees(vector<TreeHandlePtr>& trees) { trees = trees_; }
 private:
   ros::NodeHandle nh_, nhp_;
 
   /* ros param */
   double min_distance_; /* the min distance between two tree  */
   double max_radius_;  /* the max radius to use for tree update  */
-  int display_num_; /* the number of tree to display */
+  int valid_num_; /* the number of valid tree to  */
   bool verbose_;
   bool visualization_;
   string visualization_marker_topic_name_;

--- a/jsk_uav_forest_perception/include/jsk_uav_forest_perception/tree_tracking.h
+++ b/jsk_uav_forest_perception/include/jsk_uav_forest_perception/tree_tracking.h
@@ -46,6 +46,7 @@
 #include <nav_msgs/Odometry.h>
 #include <std_msgs/Bool.h>
 #include <std_srvs/SetBool.h>
+#include <std_srvs/Trigger.h>
 #include <tf/transform_broadcaster.h>
 #include <visualization_msgs/MarkerArray.h>
 
@@ -72,6 +73,7 @@ private:
   ros::Publisher pub_tree_global_location_;
 
   ros::ServiceServer tracking_control_srv_;
+  ros::ServiceServer update_target_tree_srv_;
 
   string uav_odom_topic_name_;
   string laser_scan_topic_name_;
@@ -81,6 +83,7 @@ private:
   string tree_cluster_topic_name_;
   string stop_detection_topic_name_;
   string tracking_control_srv_name_;
+  string update_target_tree_srv_name_;
 
   double uav_tilt_thre_;
   double search_radius_;
@@ -90,7 +93,7 @@ private:
   bool tree_circle_fitting_;
 
   TreeDataBase tree_db_;
-  TreeHandlePtr target_tree_;
+  vector<TreeHandlePtr> target_trees_;
 
   tf::Vector3 search_center_;
   tf::Vector3 uav_odom_;
@@ -106,6 +109,8 @@ private:
   void laserScanCallback(const sensor_msgs::LaserScanConstPtr& scan_msg);
   void uavOdomCallback(const nav_msgs::OdometryConstPtr& uav_msg);
   bool trackingControlCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
+  bool updateTargetTreeCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
+  bool searchTargetTreeFromDatabase();
   void circleFitting(const sensor_msgs::LaserScan& tree_cluster, int target_tree_index, tf::Vector3& tree_center_location, double& tree_radius);
 
 

--- a/jsk_uav_forest_perception/src/tree_database.cpp
+++ b/jsk_uav_forest_perception/src/tree_database.cpp
@@ -32,7 +32,7 @@ TreeDataBase::TreeDataBase(ros::NodeHandle nh, ros::NodeHandle nhp):nh_(nh), nhp
   trees_.resize(0);
   nhp_.param("min_distance", min_distance_, 1.0); // 1.0[m]
   nhp_.param("max_radius", max_radius_, 0.5); // 1.0[m]
-  nhp_.param("display_num", display_num_, 7);
+  nhp_.param("valid_num", valid_num_, 7);
   nhp_.param("verbose", verbose_, false);
   nhp_.param("visualization_marker_topic_name", visualization_marker_topic_name_, string("/visualization_marker"));
   pub_visualization_marker_ = nh_.advertise<visualization_msgs::MarkerArray>(visualization_marker_topic_name_, 1);
@@ -83,7 +83,7 @@ bool TreeDataBase::updateSingleTree(const tf::Vector3& tree_pos, const double& t
   else
     {
       if(verbose_  && !only_target)
-	ROS_WARN("Database tree No.%d, lost the target tree, drift: %f, the nearest target location: [%f, %f], prev target location: [%f, %f]", tree_index, min_dist, target_tree->getPos().x(), target_tree->getPos().y(), tree_pos.x(), tree_pos.y());
+	ROS_WARN("Database tree No.%d, lost the target tree, drift: %f, the nearest target location: [%f, %f, %f], prev target location: [%f, %f, %f]", tree_index, min_dist, target_tree->getPos().x(), target_tree->getPos().y(), target_tree->getPos().z(), tree_pos.x(), tree_pos.y(), tree_pos.z());
     }
 
   /* add new tree if necessary */
@@ -119,7 +119,7 @@ void TreeDataBase::visualization(std_msgs::Header header)
     size_t index = distance(trees_.begin(), it);
 
     /* only show top level trees */
-    if(index == display_num_) break;
+    if(index == valid_num_) break;
 
     visualization_msgs::Marker marker;
     marker.header.frame_id = "/world";

--- a/jsk_uav_forest_simulation/launch/forest_simulation.launch
+++ b/jsk_uav_forest_simulation/launch/forest_simulation.launch
@@ -13,6 +13,7 @@
   <arg name="turn_before_return" default="False" />
   <arg name="collision" default="false" />
   <arg name="do_mapping" default="true" />
+  <arg name="target_num" default="1" />
 
   <arg name="start_x" value="-8"/>
   <arg name="start_y" value="0" unless="$(arg collision)"/>
@@ -46,6 +47,7 @@
     <arg name="rqt_gui" value="$(arg rqt_gui)" />
     <arg name="do_avoidance" value="$(arg do_avoidance)" />
     <arg name="turn_before_return" value="$(arg turn_before_return)" />
+    <arg name="target_num" value="$(arg target_num)" />
   </include>
 
   <!-- 2D Mapping -->


### PR DESCRIPTION
You can try with following command:
```
$ roslaunch jsk_uav_forest_simulation forest_simulation.launch manual:=false gui:=false do_mapping:=true task_kind:=3 target_num:=3
```

@chibi314 
今はprev_target_treeに一番近い木を次のターゲットにして、 ``` target_num```個の木を回るようにしている。
あと、return時は最初のカラー付きの木に戻るのではなく, 直接goal pointに向かうようになっている。