### PR TITLE
Parameter tuning 

### DIFF
--- a/jsk_uav_forest_motion/config/circle_motion/circle_motion.yaml
+++ b/jsk_uav_forest_motion/config/circle_motion/circle_motion.yaml
@@ -8,10 +8,11 @@ nav_z_pos_pgain : 0.4
 nav_yaw_pgain : 1.2
 nav_xy_vel_thresh : 0.5
 nav_z_vel_thresh : 1.0
-nav_yaw_vel_thresh : 1.0
+nav_yaw_vel_thresh : 0.6
 nav_pos_convergence_thresh : 0.1
 nav_yaw_convergence_thresh : 0.1
 nav_vel_converge0.8_thresh : 1.0
 circle_radius : 1.2
-circle_y_vel : 0.2
+circle_y_vel : 0.3
 circle_motion_height_step : 0.5
+deep_return_dist: -1.2 # must be negative!


### PR DESCRIPTION

Kashiwa on 2017.5.16
1. nav_yaw_vel_thresh: decrease to slow down the yaw turn speed
2. circle_y_vel: increase the tangential velocity to shorten the circle motion duration
3. deep_return_dist: increase to go back deeply in returning phase