### PR TITLE
[jsk_uav_forest_simulation] add hector_quadrotor_gazebo in run_depend

### DIFF
--- a/jsk_uav_forest_simulation/package.xml
+++ b/jsk_uav_forest_simulation/package.xml
@@ -21,6 +21,7 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>gazebo_plugins</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>hector_quadrotor_gazebo</run_depend>
 
   <export>
     <gazebo_ros gazebo_model_path="${prefix}/gazebo_model/models" />


### PR DESCRIPTION
`run_depend` `hector_quadrotor_gazebo` is missing.