### PR TITLE
Add no_image_filter for real forest

### DIFF
--- a/jsk_uav_forest_motion/launch/motion.launch
+++ b/jsk_uav_forest_motion/launch/motion.launch
@@ -8,11 +8,13 @@
   <arg name="turn_before_return" default="True" />
   <arg name="do_avoidance" default="False" />
   <arg name="visualization" default="True" />
+  <arg name="real_forest" default="False"/>
 
   ##### Perception Node #####
   <include file="$(find jsk_uav_forest_perception)/launch/tree_detector.launch">
     <arg name="simulation" value="True" unless="$(arg use_dji)" />
     <arg name="uav_odom_topic_name" value="$(arg uav_odom_topic_name)" />
+    <arg name="real_forest" value="$(arg real_forest)"/>
   </include>
 
   ##### Motion Node #####

--- a/jsk_uav_forest_perception/CMakeLists.txt
+++ b/jsk_uav_forest_perception/CMakeLists.txt
@@ -48,7 +48,8 @@ target_link_libraries(laser_clustering_filter ${catkin_LIBRARIES})
 
 add_library(vision_detection_pluginlib
   src/vision_detector/independent_hsv_filter.cpp
-  src/vision_detector/conditional_hsv_filter.cpp)
+  src/vision_detector/conditional_hsv_filter.cpp
+  src/vision_detector/no_image_filter.cpp)
 target_link_libraries(vision_detection_pluginlib ${catkin_LIBRARIES})
 add_dependencies(vision_detection_pluginlib ${PROJECT_NAME}_gencfg)
 

--- a/jsk_uav_forest_perception/include/jsk_uav_forest_perception/vision_detector/no_image_filter.h
+++ b/jsk_uav_forest_perception/include/jsk_uav_forest_perception/vision_detector/no_image_filter.h
@@ -1,0 +1,54 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* base class */
+#include <jsk_uav_forest_perception/vision_detector_base_plugin.h>
+
+using namespace std;
+
+namespace vision_detection
+{
+  class NoImageFilter :public vision_detection::DetectorBase
+  {
+  public:
+    void initialize(ros::NodeHandle nh, ros::NodeHandle pnh) override;
+  protected:
+    bool filter(const sensor_msgs::ImageConstPtr& image_msg, const sensor_msgs::LaserScanConstPtr& scan_msg, int& target_tree_index) override;
+  private:
+    double max_distance_;
+  };
+
+};
+

--- a/jsk_uav_forest_perception/launch/tree_detector.launch
+++ b/jsk_uav_forest_perception/launch/tree_detector.launch
@@ -3,11 +3,24 @@
   <arg name="simulation" default="false" />
   <arg name="uav_odom_topic_name" default="uav_odom" />
   <arg name="image_name" default="/camera/image_rect" />
+  <arg name="real_forest" default="false"/>
 
-  <!-- vision base -->
-  <include file="$(find jsk_uav_forest_perception)/launch/image_process.launch">
-    <arg name="image_name" value="$(arg image_name)" unless="$(arg simulation)"/>
-  </include>
+  <group unless="$(arg real_forest)">
+    <!-- vision base -->
+    <include file="$(find jsk_uav_forest_perception)/launch/image_process.launch">
+      <arg name="image_name" value="$(arg image_name)" unless="$(arg simulation)"/>
+    </include>
+  </group>
+
+  <group if="$(arg real_forest)">
+    <include file="$(find jsk_uav_forest_perception)/launch/image_process.launch">
+      <arg name="plugin_name" default="NoImageFilter" />
+      <arg name="image_name" value="/dummy_image"/>
+    </include>
+
+    <node pkg="jsk_uav_forest_perception" type="dummy_image_publisher.py" name="dummy_image_publisher"/>
+  </group>
+
 
   <!-- 2D laser base -->
   <include file="$(find jsk_uav_forest_perception)/launch/laser_process.launch">
@@ -18,7 +31,7 @@
     <param name="laser_scan_topic_name" value="/scan_clustered" />
     <param name="uav_odom_topic_name" value="/ground_truth/state" if="$(arg simulation)"/>
     <param name="uav_odom_topic_name" value="$(arg uav_odom_topic_name)" unless="$(arg simulation)"/>
-    <param name="filter_rate" value="0.8" />    
+    <param name="filter_rate" value="0.8" />
     <param name="uav_tilt_thre" value="0.1" />
     <param name="tree_margin_radius" value="1.0" />
     <param name="valid_num" value="15" />
@@ -28,7 +41,7 @@
     <param name="tree_scan_angle_thre" value="0.1" />
     <param name="tree_circle_regulation_thre" value="0.02" />
     <param name="first_tree_pos_margin" value="0.5" /> <!-- positive value -->
-    <param name="first_tree_dist_thresh" value="3.0" /> <!-- positive value -->   
+    <param name="first_tree_dist_thresh" value="3.0" /> <!-- positive value -->
     <param name="narrow_searching_radius" value="4.2" />
     <param name="narrow_angle_diff_min" value="0.05" />
     <param name="max_orthogonal_dist" value="3.0" />

--- a/jsk_uav_forest_perception/param/NoImageFilter.yaml
+++ b/jsk_uav_forest_perception/param/NoImageFilter.yaml
@@ -1,0 +1,1 @@
+max_distance: 5.0

--- a/jsk_uav_forest_perception/scripts/dummy_image_publisher.py
+++ b/jsk_uav_forest_perception/scripts/dummy_image_publisher.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import rospy
+from sensor_msgs.msg import Image
+
+class DummyImagePublisher:
+    def __init__(self):
+        img_pub = rospy.Publisher("/dummy_image", Image, queue_size = 1)
+
+        r = rospy.Rate(30)
+        img_msg = Image()
+        img_msg.height = 1
+        img_msg.width = 1
+        img_msg.encoding = 'rgb8'
+        img_msg.is_bigendian = 0
+        img_msg.step = 3
+        img_msg.data = [0] * 1 * 3
+
+        while not rospy.is_shutdown():
+            img_msg.header.stamp = rospy.Time.now()
+            img_pub.publish(img_msg)
+            r.sleep()
+
+
+if __name__ == '__main__':
+    try:
+        rospy.init_node('dummy_image_publisher')
+        node = DummyImagePublisher()
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        pass

--- a/jsk_uav_forest_perception/src/vision_detector/no_image_filter.cpp
+++ b/jsk_uav_forest_perception/src/vision_detector/no_image_filter.cpp
@@ -1,0 +1,88 @@
+// -*- mode: c++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* base class */
+#include <jsk_uav_forest_perception/vision_detector/no_image_filter.h>
+
+using namespace std;
+
+namespace vision_detection
+{
+  void NoImageFilter::initialize(ros::NodeHandle nh, ros::NodeHandle pnh)
+  {
+    vision_detection::DetectorBase::initialize(nh, pnh);
+
+    pnh_.param("max_distance", max_distance_, 6.0);
+  }
+
+  bool NoImageFilter::filter(const sensor_msgs::ImageConstPtr& image_msg, const sensor_msgs::LaserScanConstPtr& scan_msg, int& target_tree_index)
+  {
+    vector<int> cluster_index;
+    for (size_t i = 0; i < scan_msg->ranges.size(); ++i)
+      {
+        if(scan_msg->ranges[i] > 0)
+            cluster_index.push_back(i);
+      }
+
+    if(cluster_index.empty())
+      return false;
+
+    float min_direction = 1e6;
+    float target_tree_laser_distance = 0.0;
+    for (auto it = cluster_index.begin(); it != cluster_index.end(); ++it)
+      {
+        float laser_direction = *it * scan_msg->angle_increment + scan_msg->angle_min;
+        float laser_distance = scan_msg->ranges[*it];
+
+        if(laser_distance < max_distance_)
+          {
+            if(fabs(laser_direction) < min_direction)
+              {
+                target_tree_index = *it;
+                min_direction = fabs(laser_direction);
+                target_tree_laser_distance = laser_distance;
+              }
+          }
+      }
+
+    ROS_ERROR("find the tree %f, %f", min_direction, target_tree_laser_distance);
+    return true;
+  }
+
+}
+
+/* plugin registration */
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(vision_detection::NoImageFilter, vision_detection::DetectorBase);

--- a/jsk_uav_forest_perception/vision_detection_plugins.xml
+++ b/jsk_uav_forest_perception/vision_detection_plugins.xml
@@ -9,5 +9,10 @@
       Conditional HSV filter.
     </description>
   </class>
+  <class name="vision_detection/NoImageFilter" type="vision_detection::NoImageFilter" base_class_type="vision_detection::DetectorBase">
+    <description>
+      No image filter (for real forest environment).
+    </description>
+  </class>
 
 </library>

--- a/jsk_uav_forest_simulation/launch/forest_simulation.launch
+++ b/jsk_uav_forest_simulation/launch/forest_simulation.launch
@@ -14,6 +14,7 @@
   <arg name="collision" default="false" />
   <arg name="do_mapping" default="true" />
   <arg name="target_num" default="1" />
+  <arg name="real_forest" default="false"/>
 
   <arg name="start_x" value="-8"/>
   <arg name="start_y" value="0" unless="$(arg collision)"/>
@@ -47,6 +48,7 @@
     <arg name="do_avoidance" value="$(arg do_avoidance)" />
     <arg name="turn_before_return" value="$(arg turn_before_return)" />
     <arg name="target_num" value="$(arg target_num)" />
+    <arg name="real_forest" value="$(arg real_forest)" />
   </include>
 
   <!-- 2D Mapping -->


### PR DESCRIPTION
木にマーカーが無いとき，一定の距離以内で真正面にある木を最初の木にするという処理をpluginとして実装しました．
#116 でConditionalHsvFilterを変更している部分を移植した形になります．
各launchファイルにreal_forestという引数を加え，TrueにするとNoImageFilterを選択するようになります．